### PR TITLE
Autostart demo to speed up development

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Feel free to contribute with features and bug fixes. Aim to follow design princi
 
 | Query parameter   | Action                    |
 |-------------------|---------------------------|
-| `startTime=<millis>`   | Set start time of the demo` |
+| `startTime=<millis>`   | Set start time of the demo |
 | `enabledLogLevels=trace,debug,info,warn,error` | Enable logging levels |
 | `autoStart=<true\|false>`  | Automatically start demo |
 | `preload=<true\|false>`  | If preload should be enabled |

--- a/README.md
+++ b/README.md
@@ -39,11 +39,22 @@ Feel free to contribute with features and bug fixes. Aim to follow design princi
 | S                 | Take a screenshot of the current rendered frame |
 | T                 | Hide/show tool |
 
+### Query parameters
+
+| Query parameter   | Action                    |
+|-------------------|---------------------------|
+| `startTime=<millis>`   | Set start time of the demo` |
+| `enabledLogLevels=trace,debug,info,warn,error` | Enable logging levels |
+| `autoStart=<true\|false>`  | Automatically start demo |
+| `preload=<true\|false>`  | If preload should be enabled |
+| `select=<path-to-demo>` | Change demo path from `data` directory to something else |
+
+If you're developing a demo and want to iterate some scene at 30.5 seconds with minimal loading times you can, for example, do following: `http://localhost:5173/?startTime=30500&autoStart=true&preload=false&select=projects/new-demo`
+
 ### Other controls
 
 - Skipping preloading: Press any rewinding key during loading
 - Mouse controls: To zoom / rotate around camera look-at (if default camera in use)
-- Query parameter `time=<millis>`: Set start time of the demo, e.g., to start at 30.5 sec mark: `http://localhost:5173/?time=30500`
 - Tool is watching for file changes automatically and attempting to do shallow reloads on changes.
 
 ## Player controls

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -38,6 +38,7 @@ Settings.prototype.init = function () {
     preloadSteps: undefined, // defaults to every 0.5s
     enabledLogLevels: ['trace', 'debug', 'info', 'warn', 'error'],
     webDemoExe: false,
+    autoStart: false,
     startTime: 0,
     fps: 60
   };
@@ -203,6 +204,10 @@ Settings.prototype.init = function () {
     this.engine.tool = false;
     this.engine.enabledLogLevels = ['info', 'warn', 'error'];
     this.engine.webDemoExe = process.env.NODE_ENV === 'exe';
+
+    if (this.engine.webDemoExe) {
+      this.engine.autoStart = true;
+    }
   }
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -469,13 +469,13 @@ function reloadDemo() {
   Effect.init('Demo');
 }
 
-function deepReloadDemo(options = {}) {
+function deepReloadDemo() {
   loggerInfo('Deep reload demo');
   const isPause = timer.isPaused();
   const time = timer.getTime();
   stopDemo();
   settings.engine.preload = false; // deep reload should not do preloading
-  restartDemo(options);
+  restartDemo();
   settings.engine.startTime = time;
   if (isPause) {
     timer.pause();

--- a/src/main.js
+++ b/src/main.js
@@ -358,13 +358,13 @@ function startDemoAnimation() {
   startAnimate();
 }
 
-function startDemo() {
+function startDemo(options = {}) {
   javaScriptFile
     .load('Demo.js')
     .then(() => {
       loggerTrace('Demo.js loaded');
       customizeSettings();
-      restartDemo();
+      restartDemo(options);
     })
     .catch(() => {
       windowSetTitle('LOADING ERROR');
@@ -380,7 +380,7 @@ function startDemo() {
     });
 }
 
-function restartDemo() {
+function restartDemo(options = {}) {
   if (Effect.loading) {
     loggerInfo('Effect is loading, not starting');
     return;
@@ -396,6 +396,16 @@ function restartDemo() {
   demoRenderer.init();
 
   togglePlayerUserInterface(true);
+
+  // without 100ms delay this explodes - maybe demoRendered should be awaited? Bindings.js:40 0.00 (1043 ms) [ERROR]: Error in loading demo: this.sceneIntro is not a function, stack: TypeError: this.sceneIntro is not a function at Demo.init (eval at <anonymous> (http://127.0.0.1:5173/src/JavaScriptFile.js:16:7), <anonymous>:198:8) at http://127.0.0.1:5173/src/Effect.js:93:16
+
+  if (options.silent === false) {
+    setTimeout(() => {
+      startDemoAnimation();
+    }, 100);
+
+    return;
+  }
 
   // HTML5 audio tag needs to be used so that WebAudio can be played also when Apple device hardware mute switch is ON
   const appleSilence = document.getElementById('appleSilence');
@@ -456,13 +466,13 @@ function reloadDemo() {
   Effect.init('Demo');
 }
 
-function deepReloadDemo() {
+function deepReloadDemo(options = {}) {
   loggerInfo('Deep reload demo');
   const isPause = timer.isPaused();
   const time = timer.getTime();
   stopDemo();
   settings.engine.preload = false; // deep reload should not do preloading
-  restartDemo();
+  restartDemo(options);
   settings.engine.startTime = time;
   if (isPause) {
     timer.pause();
@@ -580,5 +590,14 @@ document.addEventListener('keydown', (event) => {
         captureFrame();
       }, 1000);
     }
+  }
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('start') === 'yes') {
+    startDemo({
+      silent: false
+    });
   }
 });

--- a/src/main.js
+++ b/src/main.js
@@ -42,7 +42,9 @@ function setDemoPathPrefix(prefix) {
 }
 
 function setStartTime() {
-  const startTime = new URLSearchParams(window.location.search).get('time');
+  const startTime = new URLSearchParams(window.location.search).get(
+    'startTime'
+  );
   if (startTime) {
     settings.engine.startTime = parseInt(startTime);
   }
@@ -51,11 +53,16 @@ function setStartTime() {
 function customizeSettings() {
   setStartTime();
 
-  const enabledLogLevels = new URLSearchParams(window.location.search).get(
-    'enabledLogLevels'
-  );
+  const queryParams = new URLSearchParams(window.location.search);
+
+  const enabledLogLevels = queryParams.get('enabledLogLevels');
   if (enabledLogLevels) {
     settings.engine.enabledLogLevels = enabledLogLevels.split(',');
+  }
+
+  const preload = queryParams.get('preload');
+  if (preload) {
+    settings.engine.preload = preload === 'true';
   }
 }
 
@@ -81,6 +88,13 @@ window.appendDemoToPlaylist = function (name, path) {
   }
 };
 
+// auto-select the demo from the URL parameter if given
+const selectValue = new URLSearchParams(window.location.search).get('select');
+const customDemoPath = selectValue ? `${selectValue}/` : undefined;
+if (customDemoPath) {
+  setDemoPathPrefix(customDemoPath);
+}
+
 if (select) {
   // playlist.js is expected to just list available productions, e.g., appendDemoToPlaylist('JUHA 001', 'data_juha001/');
   new JavaScriptFile()
@@ -88,12 +102,8 @@ if (select) {
     .then(() => {
       loggerDebug('Initializing playlist');
 
-      // auto-select the demo from the URL parameter if given
-      const selectValue = new URLSearchParams(window.location.search).get(
-        'select'
-      );
-      if (selectValue) {
-        select.value = `${selectValue}/`;
+      if (customDemoPath) {
+        select.value = customDemoPath;
       }
 
       // if select has only one option, hide the select element
@@ -121,10 +131,6 @@ if (select) {
     .catch((e) => {
       loggerDebug('No playlist.js found, loading default demo...: ' + e);
       select.style.display = 'none';
-      // load Demo from default path if playlist.js is not defined
-      if (settings.engine.webDemoExe) {
-        startDemo();
-      }
     });
 }
 
@@ -358,13 +364,13 @@ function startDemoAnimation() {
   startAnimate();
 }
 
-function startDemo(options = {}) {
+function startDemo() {
   javaScriptFile
     .load('Demo.js')
     .then(() => {
       loggerTrace('Demo.js loaded');
       customizeSettings();
-      restartDemo(options);
+      restartDemo();
     })
     .catch(() => {
       windowSetTitle('LOADING ERROR');
@@ -380,7 +386,11 @@ function startDemo(options = {}) {
     });
 }
 
-function restartDemo(options = {}) {
+function isAppleMobileDevice() {
+  return /iPad|iPhone/.test(navigator.userAgent);
+}
+
+function restartDemo() {
   if (Effect.loading) {
     loggerInfo('Effect is loading, not starting');
     return;
@@ -397,19 +407,9 @@ function restartDemo(options = {}) {
 
   togglePlayerUserInterface(true);
 
-  // without 100ms delay this explodes - maybe demoRendered should be awaited? Bindings.js:40 0.00 (1043 ms) [ERROR]: Error in loading demo: this.sceneIntro is not a function, stack: TypeError: this.sceneIntro is not a function at Demo.init (eval at <anonymous> (http://127.0.0.1:5173/src/JavaScriptFile.js:16:7), <anonymous>:198:8) at http://127.0.0.1:5173/src/Effect.js:93:16
-
-  if (options.silent === false) {
-    setTimeout(() => {
-      startDemoAnimation();
-    }, 100);
-
-    return;
-  }
-
   // HTML5 audio tag needs to be used so that WebAudio can be played also when Apple device hardware mute switch is ON
   const appleSilence = document.getElementById('appleSilence');
-  if (appleSilence) {
+  if (appleSilence && isAppleMobileDevice()) {
     appleSilence.onseeked = () => {
       loggerDebug('AppleSilence ended');
       appleSilence.onseeked = null;
@@ -426,7 +426,10 @@ function restartDemo(options = {}) {
     appleSilence.load();
     appleSilence.play();
   } else {
-    startDemoAnimation();
+    // without 100ms delay this explodes - maybe demoRendered should be awaited? Bindings.js:40 0.00 (1043 ms) [ERROR]: Error in loading demo: this.sceneIntro is not a function, stack: TypeError: this.sceneIntro is not a function at Demo.init (eval at <anonymous> (http://127.0.0.1:5173/src/JavaScriptFile.js:16:7), <anonymous>:198:8) at http://127.0.0.1:5173/src/Effect.js:93:16
+    setTimeout(() => {
+      startDemoAnimation();
+    }, 100);
   }
 }
 window.startDemo = startDemo;
@@ -595,9 +598,11 @@ document.addEventListener('keydown', (event) => {
 
 document.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(window.location.search);
-  if (params.get('start') === 'yes') {
-    startDemo({
-      silent: false
-    });
+  if (params.get('autoStart') === 'true') {
+    settings.engine.autoStart = true;
+  }
+
+  if (settings.engine.autoStart) {
+    startDemo();
   }
 });


### PR DESCRIPTION
| Query parameter   | Action                    |
|-------------------|---------------------------|
| `startTime=<millis>`   | Set start time of the demo` |
| `enabledLogLevels=trace,debug,info,warn,error` | Enable logging levels |
| `autoStart=<true\|false>`  | Automatically start demo |
| `preload=<true\|false>`  | If preload should be enabled |
| `select=<path-to-demo>` | Change demo path from `data` directory to something else |

If you're developing a demo and want to iterate some scene at 30.5 seconds with minimal loading times you can, for example, do following: `http://localhost:5173/?startTime=30500&autoStart=true&preload=false&select=projects/new-demo`