### PR TITLE
control animation visibility with visible attribute

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -145,6 +145,7 @@ this.loader.addAnimation(
         ,"end":<time>      //end time, default is the animation block's end time
         ,"time":<time or function> //to override the animation time programmatically. start and duration/end will be honored normally.
         ,"pause":<boolean or function> //to control if animation is executed or not, can be used to pause scene drawing
+        ,"visible":<boolean or function> //to control if animation is visible or not, can be used to affect visibility of animation
         /*more animation variables per animation primitive*/
     }
      ,{/*animation primitive 2*/}

--- a/src/Player.js
+++ b/src/Player.js
@@ -732,7 +732,7 @@ Player.prototype.is3dObject = function (obj) {
 Player.prototype.handleCursorEvents = function (animation) {
   if (
     animation.cursor &&
-    animation.visible &&
+    animation._visible &&
     animation.ref &&
     this.is3dObject(animation.ref.mesh)
   ) {
@@ -775,11 +775,11 @@ Player.prototype.handleCursorEvents = function (animation) {
 };
 
 Player.prototype.setAnimationVisibility = function (animation, visible) {
-  if (animation.visible === visible) {
+  if (animation._visible === visible) {
     return;
   }
 
-  animation.visible = visible;
+  animation._visible = visible;
   if (animation.ref && this.is3dObject(animation.ref.mesh)) {
     animation.ref.mesh.visible = visible;
   }
@@ -843,8 +843,6 @@ Player.prototype.drawSceneAnimation = function (
             continue;
           }
 
-          this.setAnimationVisibility(animation, true);
-
           const currentTime =
             animation.time !== undefined
               ? startTime + Utils.evaluateVariable(animation, animation.time)
@@ -852,6 +850,17 @@ Player.prototype.drawSceneAnimation = function (
 
           if (currentTime < startTime || currentTime >= animation.end) {
             this.setAnimationVisibility(animation, false);
+            continue;
+          }
+
+          const animationVisible = Utils.evaluateVariable(
+            animation,
+            animation.visible !== undefined ? animation.visible : true
+          );
+
+          this.setAnimationVisibility(animation, animationVisible);
+
+          if (animationVisible === false) {
             continue;
           }
 


### PR DESCRIPTION
Example where animation will be visible, for 0.1 seconds each second:

```JavaScript
this.loader.addAnimation({
    text:{string:'example text',name:'multiSceneEffects/monoSpace.ttf'},
    perspective:"2d", 
    visible: () => {
      if (getSceneTimeFromStart()%1.0 > 0.1) {
        return false;
      }

      return true;
    },
});
```