### PR TITLE
chore: update threejs and remove redundant dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,9 @@
       "version": "1.0.0",
       "license": "Zlib",
       "dependencies": {
-        "ace-builds": "^1.43.2",
-        "clipboard": "^2.0.11",
         "dat.gui": "^0.7.9",
         "stats.js": "^0.17.0",
-        "three": "^0.165.0"
+        "three": "^0.179.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
@@ -2978,12 +2976,6 @@
         "win32"
       ]
     },
-    "node_modules/ace-builds": {
-      "version": "1.43.2",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.43.2.tgz",
-      "integrity": "sha512-3wzJUJX0RpMc03jo0V8Q3bSb/cKPnS7Nqqw8fVHsCCHweKMiTIxT3fP46EhjmVy6MCuxwP801ere+RW245phGw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3640,16 +3632,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/clipboard": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
-      "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
-      "dependencies": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -4045,11 +4027,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -5319,14 +5296,6 @@
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
-      "dependencies": {
-        "delegate": "^3.1.2"
-      }
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -8312,11 +8281,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA=="
-    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -8934,9 +8898,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.165.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.165.0.tgz",
-      "integrity": "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA==",
+      "version": "0.179.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.179.1.tgz",
+      "integrity": "sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==",
       "license": "MIT"
     },
     "node_modules/through": {
@@ -8945,11 +8909,6 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "node_modules/tinyexec": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,11 +32,9 @@
     "node": ">=20"
   },
   "dependencies": {
-    "ace-builds": "^1.43.2",
-    "clipboard": "^2.0.11",
     "dat.gui": "^0.7.9",
     "stats.js": "^0.17.0",
-    "three": "^0.165.0"
+    "three": "^0.179.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/src/Scene.js
+++ b/src/Scene.js
@@ -485,6 +485,18 @@ Scene.prototype.preloadMaterialProperties = function (
   }
 
   if (animationDefinition.material) {
+    if (
+      animationDefinition.material.blending &&
+      animationDefinition.material.premultipliedAlpha === undefined
+    ) {
+      if (
+        animationDefinition.material.blending === 'SubtractiveBlending' ||
+        animationDefinition.material.blending === 'MultiplyBlending'
+      ) {
+        animationDefinition.material.premultipliedAlpha = true;
+      }
+    }
+
     settings.engine.material.mapTypes.forEach((map) => {
       if (map in animationDefinition.material) {
         const mapValue = animationDefinition.material[map];


### PR DESCRIPTION
- Updated Three.js from version 0.165.0 to 0.179.1
  - Added automatic premultiplied alpha handling for Subtractive and Multiply blending modes (for backwards compatibility)
- Removed unused dependencies: ace-builds and clipboard

