### PR TITLE
support custom texture properties with material maps

### DIFF
--- a/src/Image.js
+++ b/src/Image.js
@@ -111,6 +111,24 @@ Image.prototype.createMaterial = function () {
   return material;
 };
 
+Image.prototype.setTextureProperties = function () {
+  if (this.texture[0] === undefined) {
+    throw new Error('Texture not loaded, cannot generate image mesh');
+  }
+
+  this.texture.forEach((texture, index) => {
+    const customTextureProperties =
+      (this.textureProperties instanceof Array
+        ? this.textureProperties[index]
+        : this.textureProperties) || {};
+    const textureProperties = {
+      ...settings.demo.image.texture,
+      ...customTextureProperties
+    };
+    settings.toThreeJsProperties(textureProperties, texture);
+  });
+};
+
 Image.prototype.generateMesh = function () {
   if (this.texture[0] === undefined) {
     throw new Error('Texture not loaded, cannot generate image mesh');
@@ -125,18 +143,6 @@ Image.prototype.generateMesh = function () {
       this.height = this.texture[0].image.height;
     }
   }
-
-  this.texture.forEach((texture, index) => {
-    const customTextureProperties =
-      (this.textureProperties instanceof Array
-        ? this.textureProperties[index]
-        : this.textureProperties) || {};
-    const textureProperties = {
-      ...settings.demo.image.texture,
-      ...customTextureProperties
-    };
-    settings.toThreeJsProperties(textureProperties, texture);
-  });
 
   this.material = this.createMaterial();
   // this.material = new THREE.MeshBasicMaterial({ map: this.texture[0], blending:THREE.CustomBlending, depthTest: false, depthWrite: false });
@@ -189,6 +195,8 @@ Image.prototype.loadCustomSync = function (
     );
   }
 
+  this.setTextureProperties();
+
   if (noGenerate !== true) {
     this.generateMesh();
   }
@@ -202,6 +210,8 @@ Image.prototype.load = async function (filenames, noGenerate) {
   for (let i = 0; i < filenames.length; i++) {
     await this.loadTexture(filenames[i]);
   }
+
+  this.setTextureProperties();
 
   if (noGenerate !== true) {
     this.generateMesh();

--- a/src/Scene.js
+++ b/src/Scene.js
@@ -13,7 +13,8 @@ import {
   windowSetTitle,
   loggerError,
   loggerInfo,
-  loggerDebug
+  loggerDebug,
+  loggerWarning
 } from './Bindings';
 import { Settings } from './Settings';
 
@@ -500,14 +501,28 @@ Scene.prototype.preloadMaterialProperties = function (
     settings.engine.material.mapTypes.forEach((map) => {
       if (map in animationDefinition.material) {
         const mapValue = animationDefinition.material[map];
-        if (typeof mapValue === 'string') {
-          const filename = mapValue;
-          const image = new Image();
-          if (image.isFileSupported(filename)) {
-            loggerDebug(`Preloading material '${map}': ${filename}`);
-            promises.push(image.load(filename, false));
-            animationDefinition.material[map] = image;
-          }
+        let filename = null;
+        let image = null;
+        if (
+          typeof mapValue === 'object' &&
+          mapValue !== null &&
+          'name' in mapValue
+        ) {
+          filename = mapValue.name;
+          image = new Image(mapValue);
+        } else if (typeof mapValue === 'string') {
+          filename = mapValue;
+          image = new Image();
+        } else {
+          loggerWarning(
+            `Unsupported map value for material '${map}': ${JSON.stringify(mapValue)}`
+          );
+        }
+
+        if (image && image.isFileSupported(filename)) {
+          loggerDebug(`Preloading material '${map}': ${filename}`);
+          promises.push(image.load(filename, false));
+          animationDefinition.material[map] = image;
         }
       }
     });

--- a/src/Scene.js
+++ b/src/Scene.js
@@ -521,7 +521,7 @@ Scene.prototype.preloadMaterialProperties = function (
 
         if (image && image.isFileSupported(filename)) {
           loggerDebug(`Preloading material '${map}': ${filename}`);
-          promises.push(image.load(filename, false));
+          promises.push(image.load(filename, true));
           animationDefinition.material[map] = image;
         }
       }


### PR DESCRIPTION
One use case is to create environment mapping.

## Example

```js
    material: {
      type: 'Standard',
      map: '_embedded/defaultWhite.png',
      envMap: {
        name:'img/tex_milky_way.png',
        textureProperties: {
          mapping: 'EquirectangularReflectionMapping',
        }
      } ,
      roughness: 0.1,
      metalness: 0.8
    },
```