### PR TITLE
Tool view helper and context menu features and player shader inject fix

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,8 +9,8 @@
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [5173,4173,7447]
+	// Use 'appPort' to make a list of ports inside the container available locally.
+	"appPort": [5173,4173,7447]
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "yarn install",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,8 +77,20 @@ jobs:
         path: 'release-node/'
     - run: zip -r release-node.zip release-node
       if: github.event_name == 'release'
+    - name: Build Windows Release
+      run: ./release-windows.sh
+    - name: Upload Windows Release
+      uses: actions/upload-artifact@v7
+      if: github.event_name != 'release'
+      with:
+        name: release-windows
+        path: 'dist/release-windows/'
+    - run: cd dist && zip -r ../release-windows.zip release-windows
+      if: github.event_name == 'release'
     - name: Upload Release Asset
       uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
       if: github.event_name == 'release'
       with:
-        files: release-node.zip
+        files: |
+          release-node.zip
+          release-windows.zip

--- a/README.md
+++ b/README.md
@@ -67,10 +67,33 @@ Tool controls are only enabled when tool mode (`settings.engine.tool`) is enable
 | Space             | Pause/resume demo         |
 | Home or Cmd+Left  | Rewind demo to start      |
 | End or Cmd+Right  | Rewind demo to near end   |
+| Insert            | Toggle MIDI capture overwrite |
 | P                 | Capture demo to video |
 | R                 | Deep reload demo and dispose used memory |
 | S                 | Take a screenshot of the current rendered frame |
 | T                 | Hide/show tool |
+| 0                 | Log renderer info to browser console |
+
+### Context menu
+
+Right click opens the tool context menu. All keyboard shortcuts, except the rewinding ones, are available also in the context menu.
+
+| Menu item          | Action                    |
+|--------------------|---------------------------|
+| Pause / Resume     | Pause or resume the demo |
+| Stop demo          | Stop the demo and return to the start menu |
+| Screenshot         | Take a screenshot of the current rendered frame |
+| Capture video      | Capture the demo to video, requires tool server |
+| Deep reload        | Reload the demo and dispose used memory |
+| Fullscreen         | Toggle fullscreen |
+| Hide / Show tool   | Hide or show the tool panel |
+| MIDI capture overwrite | Toggle MIDI capture overwrite, requires MIDI capture |
+| Log renderer info to console | Log renderer statistics to browser console |
+| Check unused files | List files that the demo has not loaded |
+| Camera             | Select if the view is rendered through the demo camera or freely movable orbit controls |
+| View tools         | Show or hide camera, light, grid and camera direction visualizations, see [documentation](documentation.md#view-tools) |
+| Timer              | Set demo start and loop times |
+| FBO                | Preview the contents of an FBO |
 
 ### Query parameters
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Tool controls are only enabled when tool mode (`settings.engine.tool`) is enable
 
 | Key               | Action                    |
 |-------------------|---------------------------|
+| Right click       | Open tool context menu    |
 | Left arrow        | Rewind demo -1 second     |
 | Right arrow       | Rewind demo +1 second     |
 | Down arrow        | Rewind demo -1 frame      |

--- a/documentation.md
+++ b/documentation.md
@@ -4,6 +4,7 @@
 
 * [Shader uniform autobinding](#shader-uniform-autobinding)
 * [Supported file formats](#supported-file-formats)
+* [View tools](#view-tools)
 * [Music spectogram](#music-spectogram)
 * [Demo scripting](#demo-scripting)
 * [Exporting animations from Blender](#exporting-animations)
@@ -84,6 +85,20 @@ When you save a file that has been previously loaded the engine attempts to hot 
 Shader file reloading is very efficient and fast. JavaScript and other assets may cause larger reload.
 
 Refresh cache (e.g., ctrl+F5) and restart the engine if you encounter issues.
+
+## View tools
+
+In tool mode `right click -> View tools` toggles tools that visualize where the cameras and the lights of the demo are and where they are pointing at, similarly to 3D modelling software.
+
+| View tool | Visualization |
+|-----------|---------------|
+| Cameras | Show demo camera's position and direction |
+| Lights  | Position and direction of the light |
+| Camera direction indicator | Axes of the world in the upper right corner of the screen, showing towards which axis the active camera is currently looking at |
+| Grid    | Horizontal grid plane in the origin |
+
+
+Appearance can be configured with settings `settings.tool.helpers`
 
 ## Assets processing tips and tricks
 

--- a/release-windows.sh
+++ b/release-windows.sh
@@ -4,10 +4,16 @@
 
 set -euo pipefail
 
+ENGINE_VERSION="v3.7.0"
+ENGINE_DIR="engine_v3_7_0"
+ENGINE_ZIP="${ENGINE_DIR}_windows.zip"
+ENGINE_URL="https://github.com/jumalauta/jml-engine-webgl/releases/download/${ENGINE_VERSION}/${ENGINE_ZIP}"
+ENGINE_SHA256SUM="f185bf3aa41d773d888ad247bc9291ce2f1ec2978718282a66f8b44807d7defd"
+
 rm -fr dist/
+#this canbe used to check if build works: npx vite preview
 NODE_ENV=exe npx vite build
 
-#this canbe used to check if build works: npx vite preview
 rm -rf dist/data_*
 rm -rf dist/testdata*
 rm -f dist/playlist.js
@@ -17,30 +23,23 @@ CURRENT_DIR=$(pwd)
 TMPDIR=$(mktemp -d)
 echo "Preparing release in $TMPDIR"
 
-cp -r dist/ $TMPDIR
-
 cd $TMPDIR
 
-WEBDEMOEXE_VERSION="015"
-WEBDEMOEXE_SHA256SUM="fa7724add6fa218c702814decb5710767b5ebe1b3818d6069a5ee067376454cc"
+wget "${ENGINE_URL}"
+echo "${ENGINE_SHA256SUM}  ${ENGINE_ZIP}" | sha256sum -c
+unzip -x "${ENGINE_ZIP}"
+rm -fr "${ENGINE_ZIP}"
 
-wget https://github.com/pandrr/WebDemoExe/releases/download/release${WEBDEMOEXE_VERSION}/webdemoexe_${WEBDEMOEXE_VERSION}.zip
-echo "${WEBDEMOEXE_SHA256SUM} webdemoexe_${WEBDEMOEXE_VERSION}.zip" | sha256sum -c
-unzip -x webdemoexe_${WEBDEMOEXE_VERSION}.zip
-rm -fr webdemoexe_${WEBDEMOEXE_VERSION}.zip
+# remove old project contents
+rm -fr "${ENGINE_DIR}/demo"
+mkdir -p "${ENGINE_DIR}/demo"
+mkdir -p "${ENGINE_DIR}/demo/data"
 
-cat > webdemoexe.xml <<EOF
-<config>
-	<title>JML</title>
-</config>
-EOF
-
-mv WebDemoExe.exe demo.exe
-node ${CURRENT_DIR}/change-favicon/index.js demo.exe ${CURRENT_DIR}/change-favicon/favicon.ico
-rm -fr demo
-mv dist demo
+# copy the build output, but never the 'data' directory
+find "${CURRENT_DIR}/dist" -mindepth 1 -maxdepth 1 ! -name data -exec cp -r {} "${ENGINE_DIR}/demo/" \;
 
 cd $CURRENT_DIR
-mv $TMPDIR $CURRENT_DIR/dist/release
+mv "$TMPDIR/${ENGINE_DIR}" $CURRENT_DIR/dist/release-windows
+rm -fr $TMPDIR
 
-echo Release is in dist/release - copy your 'data' directory into dist/release/demo/
+echo Release is in dist/release-windows - copy your 'data' directory contents into dist/release-windows/demo/data/

--- a/src/DemoRenderer.js
+++ b/src/DemoRenderer.js
@@ -1,5 +1,6 @@
+import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls';
-import { loggerTrace } from './Bindings';
+import { loggerInfo, loggerTrace } from './Bindings';
 import { LoadingBar } from './LoadingBar';
 import { Fbo } from './Fbo';
 import { CubeMap } from './CubeMap';
@@ -24,6 +25,8 @@ DemoRenderer.prototype.getInstance = function () {
 };
 
 let scene, camera;
+const orbitControlsMinimumDistance = 1.0;
+const orbitControlsDirection = new THREE.Vector3();
 let scenes = [];
 let cameras = [];
 let disposeList = {};
@@ -104,8 +107,9 @@ DemoRenderer.prototype.setupScene = function () {
   */
   settings.createLightsToScene(scene);
   camera = settings.createCamera();
+  this.mainCameraPlacement = undefined;
 
-  this.setOrbitControls(camera);
+  this.updateOrbitControlsCamera();
 };
 
 DemoRenderer.prototype.setScene = function (name) {
@@ -128,6 +132,14 @@ DemoRenderer.prototype.deinit = function () {
 
     this.clear();
     this.cleanScene(true);
+
+    if (this.controls) {
+      this.saveOrbitControlsTarget();
+      this.controls.dispose();
+      this.controls = null;
+    }
+
+    this.demoCamera = undefined;
 
     if (
       this.renderer.domElement &&
@@ -210,6 +222,7 @@ DemoRenderer.prototype.setOrbitControls = function (camera) {
       return;
     }
 
+    this.saveOrbitControlsTarget();
     this.controls.dispose();
     this.controls = null;
   }
@@ -224,13 +237,146 @@ DemoRenderer.prototype.setOrbitControls = function (camera) {
   }
 
   this.controls = new OrbitControls(camera, canvas);
-  //this.controls.target.set(0, 0, -10);
-  this.controls.update();
-  this.controls.enablePan = false;
+  this.controls.enablePan = this.isOrbitControlsEnabled();
   this.controls.enableDamping = true;
   this.controls.addEventListener('change', () => {
     this.renderNeedsUpdate = true;
   });
+
+  if (this.isOrbitControlsEnabled()) {
+    this.restoreOrbitControlsTarget();
+  }
+
+  this.controls.update();
+};
+
+// true = orbit controls override the camera animation of the demo
+DemoRenderer.prototype.isOrbitControlsEnabled = function () {
+  return this.orbitControlsEnabled === true;
+};
+
+DemoRenderer.prototype.isOrbitControlsActive = function () {
+  return this.isOrbitControlsEnabled() && !!this.controls;
+};
+
+DemoRenderer.prototype.getOrbitCamera = function () {
+  if (!this.orbitCamera) {
+    this.orbitCamera = settings.createCamera();
+  }
+
+  return this.orbitCamera;
+};
+
+DemoRenderer.prototype.updateOrbitControlsCamera = function () {
+  this.setOrbitControls(
+    this.isOrbitControlsEnabled() ? this.getOrbitCamera() : camera
+  );
+};
+
+DemoRenderer.prototype.setDemoCamera = function (demoCamera) {
+  this.demoCamera = demoCamera;
+};
+
+DemoRenderer.prototype.applyOrbitControls = function (followerCamera) {
+  if (!this.isOrbitControlsActive() || !followerCamera) {
+    return false;
+  }
+
+  const orbitCamera = this.controls.object;
+  if (followerCamera !== orbitCamera) {
+    followerCamera.position.copy(orbitCamera.position);
+    followerCamera.quaternion.copy(orbitCamera.quaternion);
+    followerCamera.up.copy(orbitCamera.up);
+  }
+
+  return true;
+};
+
+// demos that do not animate any camera of their own are viewed through the
+// camera of the main view, so the free camera controls it directly
+DemoRenderer.prototype.updateMainViewOrbitControls = function () {
+  if (this.isOrbitControlsActive() && !this.demoCamera && camera) {
+    if (!this.mainCameraPlacement) {
+      this.mainCameraPlacement = {
+        position: camera.position.clone(),
+        quaternion: camera.quaternion.clone(),
+        up: camera.up.clone()
+      };
+    }
+
+    this.applyOrbitControls(camera);
+  } else if (this.mainCameraPlacement) {
+    camera.position.copy(this.mainCameraPlacement.position);
+    camera.quaternion.copy(this.mainCameraPlacement.quaternion);
+    camera.up.copy(this.mainCameraPlacement.up);
+    this.mainCameraPlacement = undefined;
+  }
+};
+
+DemoRenderer.prototype.setOrbitControlsEnabled = function (enabled) {
+  this.orbitControlsEnabled = enabled === true;
+
+  if (this.orbitControlsEnabled) {
+    this.resetOrbitCameraToDemoCamera();
+
+    if (this.controls) {
+      this.controls.dispose();
+      this.controls = null;
+    }
+  }
+
+  this.updateOrbitControlsCamera();
+  this.updateMainViewOrbitControls();
+  this.renderNeedsUpdate = true;
+
+  loggerInfo(
+    `Camera controlled by ${this.orbitControlsEnabled ? 'orbit controls' : 'demo'}`
+  );
+};
+
+DemoRenderer.prototype.toggleOrbitControls = function () {
+  this.setOrbitControlsEnabled(!this.isOrbitControlsEnabled());
+};
+
+// start orbiting always from the placement of the camera of the demo
+DemoRenderer.prototype.resetOrbitCameraToDemoCamera = function () {
+  const orbitCamera = this.getOrbitCamera();
+  const demoCamera = this.demoCamera || camera;
+
+  const demoPlacement =
+    demoCamera === camera && this.mainCameraPlacement
+      ? this.mainCameraPlacement
+      : demoCamera;
+
+  if (!demoPlacement || demoCamera === orbitCamera) {
+    return;
+  }
+
+  orbitCamera.position.copy(demoPlacement.position);
+  orbitCamera.quaternion.copy(demoPlacement.quaternion);
+  orbitCamera.up.copy(demoPlacement.up);
+  orbitCamera.getWorldDirection(orbitControlsDirection);
+
+  const distance = Math.max(
+    orbitCamera.position.length(),
+    orbitControlsMinimumDistance
+  );
+
+  this.orbitTarget = orbitCamera.position
+    .clone()
+    .addScaledVector(orbitControlsDirection, distance);
+};
+
+DemoRenderer.prototype.saveOrbitControlsTarget = function () {
+  if (this.controls && this.controls.object === this.orbitCamera) {
+    this.orbitTarget = this.controls.target.clone();
+  }
+};
+
+DemoRenderer.prototype.restoreOrbitControlsTarget = function () {
+  if (this.controls && this.orbitTarget) {
+    this.controls.target.copy(this.orbitTarget);
+  }
 };
 
 DemoRenderer.prototype.renderScene = function () {
@@ -251,6 +397,8 @@ DemoRenderer.prototype.render = function () {
   new Spectogram().update();
 
   this.renderer.clear();
+
+  this.updateMainViewOrbitControls();
 
   Effect.run('Demo');
 
@@ -275,7 +423,6 @@ DemoRenderer.prototype.preload = function (percent) {
   });
 };
 
-// arry.slice(-1);
 function getScene() {
   return scenes.slice(-1)[0] || scene;
 }
@@ -308,7 +455,5 @@ window.DemoEngine = window.DemoEngine || {};
 window.DemoEngine.getRenderer = function () {
   return new DemoRenderer().renderer;
 };
-
-// alert(screenWidth + 'x' + screenHeight);
 
 export { DemoRenderer };

--- a/src/DemoRenderer.js
+++ b/src/DemoRenderer.js
@@ -6,6 +6,7 @@ import { Fbo } from './Fbo';
 import { CubeMap } from './CubeMap';
 import { Effect } from './Effect';
 import { Settings } from './Settings';
+import { SceneHelpers } from './SceneHelpers';
 import { Spectogram } from './Spectogram';
 import { ToolUi } from './ToolUi';
 import { Timer } from './Timer';
@@ -71,6 +72,8 @@ export function clearThreeObject(obj) {
 }
 
 DemoRenderer.prototype.cleanScene = function (forceDispose) {
+  new SceneHelpers().clear();
+
   Object.values(this.scenes).forEach((scene) => {
     // console.log("removing scene " + scene.uuid);
     clearThreeObject(scene);
@@ -323,6 +326,8 @@ DemoRenderer.prototype.setOrbitControlsEnabled = function (enabled) {
       this.controls.dispose();
       this.controls = null;
     }
+  } else {
+    new SceneHelpers().releaseDemoCameraProxies();
   }
 
   this.updateOrbitControlsCamera();
@@ -382,6 +387,7 @@ DemoRenderer.prototype.restoreOrbitControlsTarget = function () {
 DemoRenderer.prototype.renderScene = function () {
   if (this.renderer) {
     this.renderer.render(scene, camera);
+    new SceneHelpers().render(this.renderer, scene, camera);
   }
 };
 
@@ -401,6 +407,8 @@ DemoRenderer.prototype.render = function () {
   this.updateMainViewOrbitControls();
 
   Effect.run('Demo');
+
+  new SceneHelpers().renderOverlay(this.renderer, this.demoCamera || camera);
 
   if (this.controls) {
     this.controls.update();

--- a/src/Fbo.js
+++ b/src/Fbo.js
@@ -7,6 +7,7 @@ import {
 } from './DemoRenderer';
 import { Image } from './Image';
 import { loggerDebug } from './Bindings';
+import { SceneHelpers } from './SceneHelpers';
 import { Settings } from './Settings';
 
 const settings = new Settings();
@@ -123,6 +124,7 @@ Fbo.prototype.bind = function () {
 
 Fbo.prototype.unbind = function () {
   demoRenderer.renderer.render(this.scene, this.camera);
+  new SceneHelpers().render(demoRenderer.renderer, this.scene, this.camera);
   demoRenderer.renderer.setRenderTarget(null);
 };
 

--- a/src/Player.js
+++ b/src/Player.js
@@ -3,8 +3,15 @@ import { Utils } from './Utils';
 import { Shader } from './Shader';
 import { Timer } from './Timer';
 import { Settings } from './Settings';
-import { DemoRenderer, getScene, getCamera } from './DemoRenderer';
+import {
+  DemoRenderer,
+  getScene,
+  getCamera,
+  pushView,
+  popView
+} from './DemoRenderer';
 import { Input } from './Input';
+import { SceneHelpers } from './SceneHelpers';
 
 const settings = new Settings();
 
@@ -664,7 +671,16 @@ Player.prototype.drawCameraAnimation = function (time, animation) {
       perspective.zoom
     );
   }
-  if (!orbitControlsActive) {
+
+  const demoCameraProxy = orbitControlsActive
+    ? new SceneHelpers().getDemoCameraProxy(camera)
+    : undefined;
+
+  if (demoCameraProxy) {
+    pushView(getScene(), demoCameraProxy);
+  }
+
+  if (!orbitControlsActive || demoCameraProxy) {
     if (animation.position !== undefined) {
       const position = this.calculate3dCoordinateAnimation(
         time,
@@ -712,6 +728,10 @@ Player.prototype.drawCameraAnimation = function (time, animation) {
     if (animation.targetObject !== undefined) {
       animation.ref.setTargetObject(animation.targetObject.ptr);
     }
+  }
+
+  if (demoCameraProxy) {
+    popView();
   }
 
   animation.ref.update();

--- a/src/Player.js
+++ b/src/Player.js
@@ -573,7 +573,10 @@ Player.prototype.drawObjectAnimation = function (time, animation) {
 
 Player.prototype.drawFboAnimation = function (time, animation) {
   if (animation.fbo.debugCamera === true) {
-    new DemoRenderer().setOrbitControls(animation.ref.camera);
+    const demoRenderer = new DemoRenderer();
+    if (!demoRenderer.isOrbitControlsEnabled()) {
+      demoRenderer.setOrbitControls(animation.ref.camera);
+    }
   }
   if (animation.fbo.dimension !== undefined) {
     const obj = {
@@ -646,6 +649,11 @@ Player.prototype.drawLightAnimation = function (time, animation) {
 };
 
 Player.prototype.drawCameraAnimation = function (time, animation) {
+  const demoRenderer = new DemoRenderer();
+  const camera = getCamera();
+  demoRenderer.setDemoCamera(camera);
+  const orbitControlsActive = demoRenderer.applyOrbitControls(camera);
+
   if (animation.perspective !== undefined) {
     const perspective = this.calculatePerspectiveAnimation(time, animation);
     animation.ref.setPerspective(
@@ -656,48 +664,54 @@ Player.prototype.drawCameraAnimation = function (time, animation) {
       perspective.zoom
     );
   }
-  if (animation.position !== undefined) {
-    const position = this.calculate3dCoordinateAnimation(
-      time,
-      animation.position,
-      { x: 0, y: 0, z: 2 }
-    );
-    animation.ref.setPosition(position.x, position.y, position.z);
-  }
-  if (animation.angle !== undefined) {
-    const angle = this.calculateAngleAnimation(time, animation);
-    animation.ref.setRotation(
-      angle.degreesX,
-      angle.degreesY,
-      angle.degreesZ,
-      angle.order
-    );
-  }
-  if (animation.lookAt !== undefined) {
-    const lookAt = this.calculate3dCoordinateAnimation(time, animation.lookAt, {
-      x: 0,
-      y: 0,
-      z: 0
-    });
-    animation.ref.setLookAt(lookAt.x, lookAt.y, lookAt.z);
-  }
-  if (animation.up !== undefined) {
-    const up = this.calculate3dCoordinateAnimation(time, animation.up, {
-      x: 0,
-      y: 1,
-      z: 0
-    });
-    animation.ref.setUpVector(up.x, up.y, up.z);
-  }
+  if (!orbitControlsActive) {
+    if (animation.position !== undefined) {
+      const position = this.calculate3dCoordinateAnimation(
+        time,
+        animation.position,
+        { x: 0, y: 0, z: 2 }
+      );
+      animation.ref.setPosition(position.x, position.y, position.z);
+    }
+    if (animation.angle !== undefined) {
+      const angle = this.calculateAngleAnimation(time, animation);
+      animation.ref.setRotation(
+        angle.degreesX,
+        angle.degreesY,
+        angle.degreesZ,
+        angle.order
+      );
+    }
+    if (animation.lookAt !== undefined) {
+      const lookAt = this.calculate3dCoordinateAnimation(
+        time,
+        animation.lookAt,
+        {
+          x: 0,
+          y: 0,
+          z: 0
+        }
+      );
+      animation.ref.setLookAt(lookAt.x, lookAt.y, lookAt.z);
+    }
+    if (animation.up !== undefined) {
+      const up = this.calculate3dCoordinateAnimation(time, animation.up, {
+        x: 0,
+        y: 1,
+        z: 0
+      });
+      animation.ref.setUpVector(up.x, up.y, up.z);
+    }
 
-  animation.ref.setPositionObject();
-  if (animation.positionObject !== undefined) {
-    animation.ref.setPositionObject(animation.positionObject.ptr);
-  }
+    animation.ref.setPositionObject();
+    if (animation.positionObject !== undefined) {
+      animation.ref.setPositionObject(animation.positionObject.ptr);
+    }
 
-  animation.ref.setTargetObject();
-  if (animation.targetObject !== undefined) {
-    animation.ref.setTargetObject(animation.targetObject.ptr);
+    animation.ref.setTargetObject();
+    if (animation.targetObject !== undefined) {
+      animation.ref.setTargetObject(animation.targetObject.ptr);
+    }
   }
 
   animation.ref.update();

--- a/src/SceneHelpers.js
+++ b/src/SceneHelpers.js
@@ -1,0 +1,524 @@
+import * as THREE from 'three';
+import { RectAreaLightHelper } from 'three/addons/helpers/RectAreaLightHelper.js';
+import { ViewHelper } from 'three/addons/helpers/ViewHelper.js';
+import { loggerInfo } from './Bindings';
+import { Settings } from './Settings';
+
+const settings = new Settings();
+
+const rendererSize = new THREE.Vector2();
+const rendererViewport = new THREE.Vector4();
+
+// axis colors of View Direction Helper
+const axisColorX = 0xff4466;
+const axisColorZ = 0x4488ff;
+
+const helperRenderOrder = 100000;
+
+// projection properties copied to the demo camera
+const cameraProjectionProperties = [
+  'fov',
+  'aspect',
+  'near',
+  'far',
+  'zoom',
+  'left',
+  'right',
+  'top',
+  'bottom',
+  'filmGauge',
+  'filmOffset'
+];
+
+/** @constructor */
+const SceneHelpers = function () {
+  return this.getInstance();
+};
+
+SceneHelpers.prototype.getInstance = function () {
+  if (!SceneHelpers.prototype._singletonInstance) {
+    SceneHelpers.prototype._singletonInstance = this;
+    this.helpers = new Map();
+    this.helperScenes = new Map();
+    this.overlays = new Map();
+    this.demoCameraProxies = new Map();
+  }
+
+  return SceneHelpers.prototype._singletonInstance;
+};
+
+SceneHelpers.prototype.isLightHelpersEnabled = function () {
+  return settings.engine.tool === true && settings.tool.helpers.lights === true;
+};
+
+SceneHelpers.prototype.isCameraHelpersEnabled = function () {
+  return (
+    settings.engine.tool === true && settings.tool.helpers.cameras === true
+  );
+};
+
+SceneHelpers.prototype.setLightHelpersEnabled = function (enabled) {
+  settings.tool.helpers.lights = enabled;
+  loggerInfo(`Light helpers ${enabled === true ? 'shown' : 'hidden'}`);
+};
+
+SceneHelpers.prototype.isGridEnabled = function () {
+  return settings.engine.tool === true && settings.tool.helpers.grid === true;
+};
+
+SceneHelpers.prototype.setGridEnabled = function (enabled) {
+  settings.tool.helpers.grid = enabled;
+  loggerInfo(`Grid ${enabled === true ? 'shown' : 'hidden'}`);
+};
+
+SceneHelpers.prototype.isCameraDirectionIndicatorEnabled = function () {
+  return (
+    settings.engine.tool === true &&
+    settings.tool.helpers.cameraDirectionIndicator === true
+  );
+};
+
+SceneHelpers.prototype.setCameraDirectionIndicatorEnabled = function (enabled) {
+  settings.tool.helpers.cameraDirectionIndicator = enabled;
+  loggerInfo(
+    `Camera direction indicator ${enabled === true ? 'shown' : 'hidden'}`
+  );
+};
+
+SceneHelpers.prototype.setCameraHelpersEnabled = function (enabled) {
+  settings.tool.helpers.cameras = enabled;
+  if (!settings.tool.helpers.cameras) {
+    this.releaseDemoCameraProxies();
+  }
+  loggerInfo(`Camera helpers ${enabled === true ? 'shown' : 'hidden'}`);
+};
+
+SceneHelpers.prototype.getDemoCameraProxy = function (demoCamera) {
+  if (!this.isCameraHelpersEnabled() || !demoCamera) {
+    return undefined;
+  }
+
+  let proxy = this.demoCameraProxies.get(demoCamera);
+  if (!proxy) {
+    proxy = demoCamera.clone();
+    proxy.name = `${demoCamera.name || 'demo'}CameraProxy`;
+    this.demoCameraProxies.set(demoCamera, proxy);
+  }
+
+  cameraProjectionProperties.forEach((property) => {
+    if (demoCamera[property] !== undefined) {
+      proxy[property] = demoCamera[property];
+    }
+  });
+  proxy.updateProjectionMatrix();
+
+  return proxy;
+};
+
+SceneHelpers.prototype.releaseDemoCameraProxies = function () {
+  this.demoCameraProxies.clear();
+};
+
+SceneHelpers.prototype.createHelper = function (object) {
+  const size = settings.tool.helpers.size;
+  const color = settings.tool.helpers.lightColor;
+
+  if (object.isDirectionalLight) {
+    return new THREE.DirectionalLightHelper(object, size, color);
+  } else if (object.isHemisphereLight) {
+    return new THREE.HemisphereLightHelper(object, size, color);
+  } else if (object.isSpotLight) {
+    return new THREE.SpotLightHelper(object, color);
+  } else if (object.isRectAreaLight) {
+    return new RectAreaLightHelper(object, color);
+  } else if (object.isPointLight) {
+    return new THREE.PointLightHelper(object, size * 0.5, color);
+  } else if (object.isCamera) {
+    return new THREE.CameraHelper(object);
+  }
+
+  // not all lights have position/direction, e.g., ambient light
+  return null;
+};
+
+function forEachHelperMaterial(helper, callback) {
+  helper.traverse((object) => {
+    if (!object.material) {
+      return;
+    }
+
+    const materials = Array.isArray(object.material)
+      ? object.material
+      : [object.material];
+    materials.forEach(callback);
+  });
+}
+
+function updateHelperRendering(helper) {
+  const alwaysOnTop = settings.tool.helpers.alwaysOnTop === true;
+
+  helper.renderOrder = helperRenderOrder;
+  helper.traverse((object) => {
+    object.renderOrder = helperRenderOrder;
+  });
+
+  forEachHelperMaterial(helper, (material) => {
+    material.depthTest = !alwaysOnTop;
+    material.depthWrite = false;
+    material.fog = false;
+    material.toneMapped = false;
+  });
+}
+
+SceneHelpers.prototype.getHelperScene = function (scene) {
+  let helperScene = this.helperScenes.get(scene);
+  if (!helperScene) {
+    helperScene = new THREE.Scene();
+    this.helperScenes.set(scene, helperScene);
+  }
+
+  return helperScene;
+};
+
+SceneHelpers.prototype.addHelper = function (scene, object) {
+  let sceneHelpers = this.helpers.get(scene);
+  if (!sceneHelpers) {
+    sceneHelpers = new Map();
+    this.helpers.set(scene, sceneHelpers);
+  }
+
+  if (sceneHelpers.has(object)) {
+    return sceneHelpers.get(object);
+  }
+
+  const helper = this.createHelper(object);
+  sceneHelpers.set(object, helper);
+
+  if (helper) {
+    helper.userData.sceneHelper = true;
+    this.getHelperScene(scene).add(helper);
+  }
+
+  return helper;
+};
+
+SceneHelpers.prototype.removeHelper = function (helper) {
+  if (!helper) {
+    return;
+  }
+
+  if (helper.parent) {
+    helper.parent.remove(helper);
+  }
+
+  if (helper.dispose) {
+    helper.dispose();
+  }
+};
+
+SceneHelpers.prototype.removeUnusedHelpers = function (scene, objects) {
+  const sceneHelpers = this.helpers.get(scene);
+  if (!sceneHelpers) {
+    return;
+  }
+
+  sceneHelpers.forEach((helper, object) => {
+    if (objects.has(object)) {
+      return;
+    }
+
+    this.removeHelper(helper);
+    sceneHelpers.delete(object);
+  });
+
+  if (sceneHelpers.size === 0) {
+    this.helpers.delete(scene);
+    this.helperScenes.delete(scene);
+  }
+};
+
+function isObjectVisible(object) {
+  let current = object;
+  while (current) {
+    if (current.visible === false) {
+      return false;
+    }
+    current = current.parent;
+  }
+
+  return true;
+}
+
+SceneHelpers.prototype.clear = function () {
+  this.helpers.forEach((sceneHelpers) => {
+    sceneHelpers.forEach((helper) => this.removeHelper(helper));
+  });
+
+  this.helpers.clear();
+  this.helperScenes.clear();
+  this.overlays.clear();
+  this.releaseDemoCameraProxies();
+
+  this.disposeGrid();
+};
+
+SceneHelpers.prototype.update = function (scene, renderCamera) {
+  if (!scene) {
+    return;
+  }
+
+  const lightHelpers = this.isLightHelpersEnabled();
+  const cameraHelpers = this.isCameraHelpersEnabled();
+
+  if (!lightHelpers && !cameraHelpers && !this.helpers.has(scene)) {
+    return;
+  }
+
+  const objects = new Set();
+
+  if (lightHelpers || cameraHelpers) {
+    scene.traverse((object) => {
+      if (object.userData.sceneHelper === true) {
+        return;
+      }
+
+      if (lightHelpers && object.isLight) {
+        objects.add(object);
+      } else if (cameraHelpers && object.isCamera && object !== renderCamera) {
+        objects.add(object);
+      }
+    });
+  }
+
+  const demoCameraProxy = cameraHelpers
+    ? this.demoCameraProxies.get(renderCamera)
+    : undefined;
+  if (demoCameraProxy) {
+    demoCameraProxy.updateMatrixWorld(true);
+    objects.add(demoCameraProxy);
+  }
+
+  this.removeUnusedHelpers(scene, objects);
+
+  if (objects.size === 0) {
+    return;
+  }
+
+  objects.forEach((object) => this.addHelper(scene, object));
+
+  scene.updateMatrixWorld(true);
+
+  this.helpers.get(scene).forEach((helper, object) => {
+    if (!helper) {
+      return;
+    }
+
+    helper.visible = isObjectVisible(object);
+    if (!helper.visible) {
+      return;
+    }
+
+    updateHelperRendering(helper);
+    if (helper.update) {
+      helper.update();
+    }
+  });
+};
+
+// helpers are drawn as an own pass on top of the rendered scene, so that the
+// demo can not draw over them in post-processing passes
+SceneHelpers.prototype.render = function (renderer, scene, renderCamera) {
+  this.update(scene, renderCamera);
+
+  const helperScene = this.helperScenes.get(scene);
+  if (!renderer || !renderCamera || !helperScene) {
+    return;
+  }
+
+  if (helperScene.children.length === 0) {
+    return;
+  }
+
+  if (settings.tool.helpers.overlay === true) {
+    this.overlays.set(helperScene, renderCamera);
+    return;
+  }
+
+  const autoClear = renderer.autoClear;
+  renderer.autoClear = false;
+  renderer.render(helperScene, renderCamera);
+  renderer.autoClear = autoClear;
+};
+
+function createGridAxisLine(from, to, color) {
+  const geometry = new THREE.BufferGeometry().setFromPoints([from, to]);
+  const material = new THREE.LineBasicMaterial({
+    color,
+    fog: false,
+    toneMapped: false,
+    depthTest: false,
+    depthWrite: false
+  });
+
+  const line = new THREE.Line(geometry, material);
+  line.renderOrder = 1;
+
+  return line;
+}
+
+SceneHelpers.prototype.getGrid = function () {
+  if (!this.grid) {
+    const size = settings.tool.helpers.gridSize;
+    const half = size / 2;
+    const color = settings.tool.helpers.gridColor;
+
+    const grid = new THREE.GridHelper(
+      size,
+      Math.max(1, Math.round(settings.tool.helpers.gridDivisions)),
+      color,
+      color
+    );
+    grid.material.fog = false;
+    grid.material.toneMapped = false;
+    grid.material.depthTest = false;
+    grid.material.depthWrite = false;
+    grid.material.transparent = true;
+    grid.material.opacity = settings.tool.helpers.gridOpacity;
+
+    this.grid = new THREE.Scene();
+    this.grid.add(grid);
+
+    this.grid.add(
+      createGridAxisLine(
+        new THREE.Vector3(-half, 0, 0),
+        new THREE.Vector3(half, 0, 0),
+        axisColorX
+      )
+    );
+    this.grid.add(
+      createGridAxisLine(
+        new THREE.Vector3(0, 0, -half),
+        new THREE.Vector3(0, 0, half),
+        axisColorZ
+      )
+    );
+  }
+
+  return this.grid;
+};
+
+SceneHelpers.prototype.disposeGrid = function () {
+  if (!this.grid) {
+    return;
+  }
+
+  this.grid.traverse((object) => {
+    if (object.geometry) {
+      object.geometry.dispose();
+    }
+    if (object.material) {
+      object.material.dispose();
+    }
+  });
+
+  this.grid = undefined;
+};
+
+SceneHelpers.prototype.renderGrid = function (renderer, viewCamera) {
+  if (!viewCamera) {
+    return;
+  }
+
+  renderer.render(this.getGrid(), viewCamera);
+};
+
+SceneHelpers.prototype.getCameraDirectionIndicator = function () {
+  if (!this.cameraDirectionIndicator) {
+    this.cameraDirectionIndicatorCamera = new THREE.PerspectiveCamera();
+    this.cameraDirectionIndicator = new ViewHelper(
+      this.cameraDirectionIndicatorCamera
+    );
+    this.cameraDirectionIndicator.setLabels('X', 'Y', 'Z');
+
+    this.cameraDirectionIndicatorView = new THREE.OrthographicCamera(
+      -2,
+      2,
+      2,
+      -2,
+      0,
+      4
+    );
+    this.cameraDirectionIndicatorView.position.set(0, 0, 2);
+  }
+
+  return this.cameraDirectionIndicator;
+};
+
+// indicator in the corner of the screen showing towards which axis the active camera is looking at
+SceneHelpers.prototype.renderCameraDirectionIndicator = function (
+  renderer,
+  viewCamera
+) {
+  if (!viewCamera) {
+    return;
+  }
+
+  const indicator = this.getCameraDirectionIndicator();
+  viewCamera.getWorldQuaternion(this.cameraDirectionIndicatorCamera.quaternion);
+  indicator.quaternion
+    .copy(this.cameraDirectionIndicatorCamera.quaternion)
+    .invert();
+  indicator.updateMatrixWorld();
+
+  // drawn to the upper right corner of the screen
+  const size = Math.max(1, settings.tool.helpers.cameraDirectionIndicatorSize);
+  renderer.getSize(rendererSize);
+  renderer.getViewport(rendererViewport);
+
+  renderer.clearDepth();
+  renderer.setViewport(
+    rendererSize.x - size,
+    rendererSize.y - size,
+    size,
+    size
+  );
+  renderer.render(indicator, this.cameraDirectionIndicatorView);
+  renderer.setViewport(
+    rendererViewport.x,
+    rendererViewport.y,
+    rendererViewport.z,
+    rendererViewport.w
+  );
+};
+
+SceneHelpers.prototype.renderOverlay = function (renderer, viewCamera) {
+  const cameraDirectionIndicator = this.isCameraDirectionIndicatorEnabled();
+  const grid = this.isGridEnabled();
+  if (
+    !renderer ||
+    (this.overlays.size === 0 && !cameraDirectionIndicator && !grid)
+  ) {
+    return;
+  }
+
+  const autoClear = renderer.autoClear;
+  renderer.autoClear = false;
+  renderer.setRenderTarget(null);
+
+  if (grid) {
+    this.renderGrid(renderer, viewCamera);
+  }
+
+  this.overlays.forEach((renderCamera, helperScene) => {
+    renderer.render(helperScene, renderCamera);
+  });
+  this.overlays.clear();
+
+  if (cameraDirectionIndicator) {
+    this.renderCameraDirectionIndicator(renderer, viewCamera);
+  }
+
+  renderer.autoClear = autoClear;
+};
+
+export { SceneHelpers };

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -80,6 +80,21 @@ Settings.prototype.init = function () {
       capture: true, // capture MIDI events
       playbackLogging: true, // enable playback logging
       recordingName: 'default' // name of the MIDI recording
+    },
+    helpers: {
+      cameras: false, // draw demo camera position and direction
+      lights: false, // draw light position and directions
+      cameraDirectionIndicator: false, // draw an indicator to the upper right corner of the screen showing towards which axis the camera is looking at
+      cameraDirectionIndicatorSize: 128, // size of the camera direction indicator in pixels
+      grid: false, // draw a horizontal grid plane to the origin
+      gridSize: 20.0, // width and depth of the grid in world units
+      gridDivisions: 20, // number of grid cells per grid axis
+      gridColor: 0x888888, // default color of the grid lines
+      gridOpacity: 0.5, // opacity of the grid lines
+      size: 1.0, // size of the light helper gizmo in world units
+      lightColor: undefined, // light helper color, undefined = the color of the light
+      alwaysOnTop: true, // true = helpers are drawn on top of geometry
+      overlay: true // true = helpers are drawn on the screen after the demo, false = drawn to the render target of the scene, i.e., demo's post-processing effects are applied to the helpers
     }
   };
 

--- a/src/Shader.js
+++ b/src/Shader.js
@@ -476,7 +476,6 @@ Shader.injectInlineShaderCode = function (shader, ref, options) {
 
   // Point every derived material at the same uniform so uniform update affects the color and shadow pass
   const shared = ref.getInlineUniforms();
-  shader.uniforms = THREE.UniformsUtils.merge([shader.uniforms, shared]);
   Object.keys(shared).forEach((name) => {
     shader.uniforms[name] = shared[name];
   });
@@ -580,18 +579,18 @@ Shader.enableShader = function (animation) {
         animation.shader.ref.material.uniforms ||
         animation.shader.ref.material.userData.shader.uniforms;
       animation.shader.variable.forEach((variable) => {
+        if (uniforms[variable.name] === undefined) {
+          loggerWarning(
+            `Uniform '${variable.name}' not found, cannot set value. Available uniforms: ${Object.keys(uniforms).join(', ')}`
+          );
+          return;
+        }
+
         if (variable.value !== undefined) {
           uniforms[variable.name].value = Shader.convertToThreeJsUniformValues([
             ...variable.value
           ]);
         } else {
-          if (uniforms[variable.name] === undefined) {
-            loggerWarning(
-              `Uniform '${variable.name}' not found, cannot set value. Available uniforms: ${Object.keys(uniforms).join(', ')}`
-            );
-            return;
-          }
-
           if (variable.name === 'texture0' && animation.ref.texture) {
             uniforms[variable.name].value = animation.ref.texture[0];
           } else if (

--- a/src/ToolUi.js
+++ b/src/ToolUi.js
@@ -17,7 +17,20 @@ import { loggerInfo, loggerWarning } from './Bindings';
 import { Utils } from './Utils';
 import { Fbo } from './Fbo';
 import { DemoRenderer } from './DemoRenderer';
+import { Fullscreen } from './Fullscreen';
+import { MidiManager } from './MidiManager';
+import { SceneHelpers } from './SceneHelpers';
 import { ToolClient } from './ToolClient';
+import {
+  deepReloadDemo,
+  logRendererInfo,
+  screenshot,
+  startVideoCapture,
+  stopDemo,
+  toggleFullscreen,
+  toggleMidiCaptureOverwrite,
+  toggleToolUi
+} from './main';
 import './ToolUi.css';
 
 const settings = new Settings();
@@ -356,12 +369,70 @@ ToolUi.prototype.getMenuItems = function () {
   const isPaused = timer.isPaused();
   const demoRenderer = new DemoRenderer();
   const isOrbitControlsEnabled = demoRenderer.isOrbitControlsEnabled();
+  const sceneHelpers = new SceneHelpers();
+  const isCameraHelpersEnabled = sceneHelpers.isCameraHelpersEnabled();
+  const isLightHelpersEnabled = sceneHelpers.isLightHelpersEnabled();
+  const isCameraDirectionIndicatorEnabled =
+    sceneHelpers.isCameraDirectionIndicatorEnabled();
+  const isGridEnabled = sceneHelpers.isGridEnabled();
+  const fullscreen = new Fullscreen();
+  const midiManager = new MidiManager();
 
   return [
     {
-      label: isPaused ? 'Resume' : 'Pause',
+      label: `${isPaused ? 'Resume' : 'Pause'} (Space)`,
       action: () => {
         timer.pause(!isPaused);
+      }
+    },
+    {
+      label: 'Stop demo (Esc)',
+      action: () => {
+        stopDemo();
+      }
+    },
+    {
+      label: 'Screenshot (S)',
+      action: () => {
+        screenshot();
+      }
+    },
+    {
+      label: 'Capture video (P)',
+      action: () => {
+        startVideoCapture();
+      }
+    },
+    {
+      label: 'Deep reload (R)',
+      action: () => {
+        deepReloadDemo();
+      }
+    },
+    {
+      label: `${fullscreen.isFullscreen() ? '✔ ' : ''}Fullscreen (F)`,
+      disabled: !fullscreen.isFullscreenSupported(),
+      action: () => {
+        toggleFullscreen();
+      }
+    },
+    {
+      label: `${this.isVisible() ? 'Hide' : 'Show'} tool (T)`,
+      action: () => {
+        toggleToolUi();
+      }
+    },
+    {
+      label: `${midiManager.isCaptureOverwrite() ? '✔ ' : ''}MIDI capture overwrite (Insert)`,
+      disabled: !midiManager.capture,
+      action: () => {
+        toggleMidiCaptureOverwrite();
+      }
+    },
+    {
+      label: 'Log renderer info to console (0)',
+      action: () => {
+        logRendererInfo();
       }
     },
     {
@@ -384,6 +455,46 @@ ToolUi.prototype.getMenuItems = function () {
           label: `${isOrbitControlsEnabled ? '✔ ' : ''}Orbit controls`,
           action: () => {
             demoRenderer.setOrbitControlsEnabled(true);
+          }
+        }
+      ]
+    },
+    {
+      label: 'View tools',
+      children: [
+        {
+          label: `${isCameraHelpersEnabled ? '✔ ' : ''}Cameras`,
+          action: () => {
+            sceneHelpers.setCameraHelpersEnabled(!isCameraHelpersEnabled);
+            if (!isCameraHelpersEnabled && !isOrbitControlsEnabled) {
+              loggerInfo(
+                'Demo camera is visible only when the view is rendered through orbit controls'
+              );
+            }
+            demoRenderer.setRenderNeedsUpdate(true);
+          }
+        },
+        {
+          label: `${isLightHelpersEnabled ? '✔ ' : ''}Lights`,
+          action: () => {
+            sceneHelpers.setLightHelpersEnabled(!isLightHelpersEnabled);
+            demoRenderer.setRenderNeedsUpdate(true);
+          }
+        },
+        {
+          label: `${isGridEnabled ? '✔ ' : ''}Grid`,
+          action: () => {
+            sceneHelpers.setGridEnabled(!isGridEnabled);
+            demoRenderer.setRenderNeedsUpdate(true);
+          }
+        },
+        {
+          label: `${isCameraDirectionIndicatorEnabled ? '✔ ' : ''}Camera direction indicator`,
+          action: () => {
+            sceneHelpers.setCameraDirectionIndicatorEnabled(
+              !isCameraDirectionIndicatorEnabled
+            );
+            demoRenderer.setRenderNeedsUpdate(true);
           }
         }
       ]

--- a/src/ToolUi.js
+++ b/src/ToolUi.js
@@ -354,6 +354,8 @@ ToolUi.prototype.getMenuItems = function () {
   const timer = new Timer();
   const fbos = Fbo.getFbos();
   const isPaused = timer.isPaused();
+  const demoRenderer = new DemoRenderer();
+  const isOrbitControlsEnabled = demoRenderer.isOrbitControlsEnabled();
 
   return [
     {
@@ -368,6 +370,23 @@ ToolUi.prototype.getMenuItems = function () {
         const toolClient = new ToolClient();
         toolClient.showUnusedFiles();
       }
+    },
+    {
+      label: 'Camera',
+      children: [
+        {
+          label: `${!isOrbitControlsEnabled ? '✔ ' : ''}Demo camera`,
+          action: () => {
+            demoRenderer.setOrbitControlsEnabled(false);
+          }
+        },
+        {
+          label: `${isOrbitControlsEnabled ? '✔ ' : ''}Orbit controls`,
+          action: () => {
+            demoRenderer.setOrbitControlsEnabled(true);
+          }
+        }
+      ]
     },
     {
       label: 'Timer',

--- a/src/main.js
+++ b/src/main.js
@@ -311,7 +311,7 @@ function canvasToDataUrl() {
   return dataUrl;
 }
 
-function screenshot() {
+export function screenshot() {
   const canvas = document.getElementById('canvas');
   Utils.takeCanvasScreenshot(canvas);
 }
@@ -707,7 +707,7 @@ function reloadDemo() {
   Effect.init('Demo');
 }
 
-function deepReloadDemo() {
+export function deepReloadDemo() {
   loggerInfo('Deep reload demo');
   const isPause = timer.isPaused();
   const time = timer.getTime();
@@ -749,6 +749,73 @@ function rewindToStart() {
 
 function rewindToEnd() {
   timer.setTimePercent(0.99);
+}
+
+export function toggleFullscreen() {
+  fullscreen.toggleFullscreen(!fullscreen.isFullscreen());
+}
+
+export function toggleToolUi() {
+  if (toolUi.isVisible()) {
+    toolUi.hide();
+  } else {
+    toolUi.show();
+  }
+
+  windowResize();
+}
+
+export function toggleMidiCaptureOverwrite() {
+  const midiManager = new MidiManager();
+  if (midiManager.capture) {
+    midiManager.setCaptureOverwrite(!midiManager.isCaptureOverwrite());
+  }
+}
+
+export function logRendererInfo() {
+  console.log(demoRenderer.renderer.info);
+}
+
+export function startVideoCapture() {
+  if (!isStarted()) {
+    return;
+  }
+
+  if (!toolClient.isConnected()) {
+    alert('Tool server not connected, cannot capture');
+    return;
+  }
+
+  if (!confirm('Want to start video capture?')) {
+    return;
+  }
+
+  timer.pause(true);
+  timer.setTime(0);
+  captureStartTime = Date.now();
+  toolClient
+    .request('capture.start', {
+      fps: settings.engine.fps,
+      width: 1920,
+      height: 1080
+    })
+    .then((result) => {
+      loggerInfo('Capture started successfully');
+
+      setTimeout(() => {
+        frame = -1;
+        capture = true;
+        setWaitingForFrame(true);
+        captureFrame();
+      }, 1000);
+
+      return result;
+    })
+    .catch((err) => {
+      loggerError('Failed to start capture: ' + err.message);
+      alert('Failed to start video capture');
+      throw err;
+    });
 }
 
 if (settings.engine.pauseOnInvisibility) {
@@ -798,7 +865,7 @@ document.addEventListener('keydown', (event) => {
       startDemo();
     }
   } else if (event.key === 'f') {
-    fullscreen.toggleFullscreen(!fullscreen.isFullscreen());
+    toggleFullscreen();
   } else if (settings.engine.tool) {
     if (event.key === 'ArrowLeft') {
       if (event.metaKey) {
@@ -827,68 +894,21 @@ document.addEventListener('keydown', (event) => {
     } else if (event.code === 'Space') {
       timer.pause();
     } else if (event.key === 'Insert') {
-      const midiManager = new MidiManager();
-      if (midiManager.capture) {
-        midiManager.setCaptureOverwrite(!midiManager.isCaptureOverwrite());
-      }
+      toggleMidiCaptureOverwrite();
     } else if (event.key === '0') {
-      /* performance.measureUserAgentSpecificMemory().finally((result) => {
-        console.log(result);
-      }); */
-
-      console.log(demoRenderer.renderer.info);
+      logRendererInfo();
     } else if (event.key === 'r') {
       deepReloadDemo();
     } else if (event.key === 's') {
       screenshot();
     } else if (event.key === 't') {
-      if (toolUi.isVisible()) {
-        toolUi.hide();
-      } else {
-        toolUi.show();
-      }
-
-      windowResize();
+      toggleToolUi();
     } else if (event.key === 'End') {
       rewindToEnd();
     } else if (event.key === 'Home') {
       rewindToStart();
-    } else if (event.key === 'p' && isStarted()) {
-      if (!toolClient.isConnected()) {
-        alert('Tool server not connected, cannot capture');
-        return;
-      }
-
-      if (!confirm('Want to start video capture?')) {
-        return;
-      }
-
-      timer.pause(true);
-      timer.setTime(0);
-      captureStartTime = Date.now();
-      toolClient
-        .request('capture.start', {
-          fps: settings.engine.fps,
-          width: 1920,
-          height: 1080
-        })
-        .then((result) => {
-          loggerInfo('Capture started successfully');
-
-          setTimeout(() => {
-            frame = -1;
-            capture = true;
-            setWaitingForFrame(true);
-            captureFrame();
-          }, 1000);
-
-          return result;
-        })
-        .catch((err) => {
-          loggerError('Failed to start capture: ' + err.message);
-          alert('Failed to start video capture');
-          throw err;
-        });
+    } else if (event.key === 'p') {
+      startVideoCapture();
     }
   }
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -120,7 +120,7 @@ export default defineConfig(({ command }) => {
       appType: 'mpa', // proper 404 responses instead of index.html fallback
       server: {
         hmr: false,
-        host: '127.0.0.1',
+        host: true,
         open: true,
         headers: {
           'Cache-Control':


### PR DESCRIPTION
- Enable hijacking demo active camera with orbit controls
- View helper tools:
  - Origin grid
  - View direction indicator
  - Render camera position and direction
  - Render light position and direction
- Key shortcuts available in context menu
- fix: shader inline uniform injection fails for images
 - Injecting fragment shader code and uniforms to an image didn't work previously
- chore: use direct ports instead of VSCode port forward
  - This might have caused loading issues when loading bigger assets (large MP3) from devcontainer 
- Windows release build in GitHub actions